### PR TITLE
fixing a bug -

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ IMAGES=("word-games-nginx:latest" "word-games-backend:latest")  # List of Docker
 #     rm "$(basename "$IMAGE").tar"
 # done
 
-# INSTALL_DIR="~/deployments/$PROJECT_NAME"
+INSTALL_DIR="~/deployments/$PROJECT_NAME"
 # # ??
 # # ssh "$SERVER_USER@$SERVER_IP" "mkdir -p $INSTALL_DIR"
 

--- a/packages/backend/src/service/pyramidService.ts
+++ b/packages/backend/src/service/pyramidService.ts
@@ -69,8 +69,8 @@ export const makePyramidService = (
     const { allPyramidSolutions, graph } = result
 
     const rand = seedrandom(strSeed)
-    const pyramid =
-      allPyramidSolutions[Math.floor(rand() * allPyramidSolutions.length)]
+    const randomIndex = Math.floor(rand() * allPyramidSolutions.length)
+    const pyramid = allPyramidSolutions[randomIndex]
 
     const startingWord = pyramid[0]
     // copy subgraph of solutions for verification later
@@ -145,7 +145,16 @@ export const makePyramidService = (
 
     return [
       null,
-      { prompt: pyramidPrompt, solutionPrompt, subgraphOfSolutions },
+      // prompt - the orignal prompt
+      // solutionPrompt - one actual solution
+      // subgraphOfSolutions - all possible solutions
+      // allSolutionsStartingAtStartWord - flattened subgraphOfSolutions
+      {
+        prompt: pyramidPrompt,
+        solutionPrompt,
+        subgraphOfSolutions,
+        allSolutionsStartingAtStartWord,
+      },
     ] as const
   }
 

--- a/packages/common/src/word-utils/anagramLookup.ts
+++ b/packages/common/src/word-utils/anagramLookup.ts
@@ -1,22 +1,22 @@
 export const makeAnagramLookup = () => {
-  const anagramMap = new Map<string, Set<string>>();
+  const anagramMap = new Map<string, Set<string>>()
 
-  const toHash = (word: string) => word.split("").sort().join("");
+  const toHash = (word: string) => word.split("").sort().join("")
   // insert adds the word itself
   const insert = (word: string) => {
-    const hash = toHash(word);
-    const anagramGroup = anagramMap.get(hash) ?? new Set();
-    anagramGroup.add(word);
-    anagramMap.set(hash, anagramGroup);
-  };
-  const getAnagrams = (word: string) => anagramMap.get(word);
+    const hash = toHash(word)
+    const anagramGroup = anagramMap.get(hash) ?? new Set()
+    anagramGroup.add(word)
+    anagramMap.set(hash, anagramGroup)
+  }
+  const getAnagrams = (word: string) => anagramMap.get(toHash(word))
 
-  const getAll = () => anagramMap;
+  const getAll = () => anagramMap
 
   return {
     insert,
     getAnagrams,
     getAll,
-  };
-};
-export type AnagramLookup = ReturnType<typeof makeAnagramLookup>;
+  }
+}
+export type AnagramLookup = ReturnType<typeof makeAnagramLookup>


### PR DESCRIPTION
given a prompt like

"b l o a t"
"b _ _ _"
"_ _ _"
"_ _"
"o"

I would attempt to enter

"bloat"
"boat"
"bot"
"to"
"o"

But it would be invalid.  That was because the anagram lookup helper had a bug in it.  Anagram lookup is supposed insert a hash key, and value set as words are added - but it wasn't retrieving keys based on the hash.

Example:

```ts
anagramLookup.insert("boat") => "abot": ["boat"]
anagramLookup.insert("tabo") => "abot": ["boat", "tabo"]
```
however
anagramlookup.get("boat") was not using the hash, so it'd return null - 