### PR TITLE
fixing OOM on pyramid generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     build:
       context: packages/backend
     platform: linux/arm64/v8
+    environment:
+      - NODE_OPTIONS=--max-old-space-size=4096
     volumes:
       - word-games-backend-data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
     build:
       context: packages/backend
     platform: linux/arm64/v8
-    environment:
-      - NODE_OPTIONS=--max-old-space-size=4096
+    # environment:
+    #   - NODE_OPTIONS=--max-old-space-size=4096
     volumes:
       - word-games-backend-data:/data
     ports:
       - "12346:4000"
-    restart: unless-stopped
+    # restart: unless-stopped
 
 volumes:
   word-games-backend-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - word-games-backend-data:/data
     ports:
       - "12346:4000"
-    # restart: unless-stopped
+    restart: unless-stopped
 
 volumes:
   word-games-backend-data:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rollup -c rollup.config.js",
     "offline": "vite-node ./src/offline.ts",
-    "start": "vite-node -w src/main.ts",
+    "start": "NODE_OPTIONS=\"--max-old-space-size=4096\" vite-node -w src/main.ts",
     "test": "vitest",
     "type-check": "tsc --noEmit"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rollup -c rollup.config.js",
     "offline": "vite-node ./src/offline.ts",
-    "start": "NODE_OPTIONS=\"--max-old-space-size=4096\" vite-node -w src/main.ts",
+    "start": "NODE_OPTIONS=\"--max-old-space-size=1024\" vite-node -w src/main.ts",
     "test": "vitest",
     "type-check": "tsc --noEmit"
   },

--- a/packages/backend/rollup.config.js
+++ b/packages/backend/rollup.config.js
@@ -50,7 +50,6 @@ const getEnv = () => {
   return env
 }
 
-console.log("hello")
 export default defineConfig({
   input: "src/main.ts", // Entry point of your application
   output: {

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -3,8 +3,10 @@ import cors from "cors"
 import express from "express"
 import { metaHotTeardown } from "./metaHotTeardown"
 import { makeAppRouter } from "./router"
+import v8 from 'v8'
 
 const main = async () => {
+  console.log('v8.getHeapStatistics.heap_size_limit', v8.getHeapStatistics().heap_size_limit / 1024 / 1024, 'MB');
   const app = express()
 
   app.use(

--- a/packages/backend/src/router.ts
+++ b/packages/backend/src/router.ts
@@ -133,6 +133,7 @@ export const makeAppRouter = async () => {
   const { pyramidService, userService } = await bootstrap()
   return router({
     getPyramidOfTheDay: publicProcedure.query(async () => {
+
       const [err, result] = await pyramidService.getPyramidOfTheDay()
 
       if (err) {

--- a/packages/backend/src/service/pyramidService.ts
+++ b/packages/backend/src/service/pyramidService.ts
@@ -14,6 +14,7 @@ export const makePyramidService = (
   store: PyramidStoreAdapter,
 ) => {
   const getAllPyramids = async () => {
+    console.time("[PyramidService] getAllPyramids");
     const [getWordsErr, words] = await wordStore.getWords()
     if (getWordsErr) {
       return [getWordsErr, null] as const
@@ -55,6 +56,7 @@ export const makePyramidService = (
       findAllPyramids(graph, anagramLookup, allPyramidSolutions, w, 5, [])
     }
 
+    console.timeEnd("[PyramidService] getAllPyramids");
     return [null, { allPyramidSolutions, graph }] as const
   }
 
@@ -65,7 +67,6 @@ export const makePyramidService = (
       console.error("[pyramidService] Error generating game", err)
       return [err, null] as const
     }
-
     const { allPyramidSolutions, graph } = result
 
     const rand = seedrandom(strSeed)
@@ -75,6 +76,7 @@ export const makePyramidService = (
     const startingWord = pyramid[0]
     // copy subgraph of solutions for verification later
     const subgraphOfSolutions = makeWordRelationGraph()
+
     graph.copy(subgraphOfSolutions, startingWord)
 
     // Build the prompt - to be served to the UI
@@ -112,7 +114,6 @@ export const makePyramidService = (
         cell.character = ""
       }
     }
-
     // reduce the subgraph of solutions
     subgraphOfSolutions.filterRelations((from: string, to: string) => {
       const layerIdx = startingWord.length - to.length

--- a/packages/backend/src/service/pyramidService.ts
+++ b/packages/backend/src/service/pyramidService.ts
@@ -14,11 +14,13 @@ export const makePyramidService = (
   store: PyramidStoreAdapter,
 ) => {
   const getAllPyramids = async () => {
-    console.time("[PyramidService] getAllPyramids");
-    const [getWordsErr, words] = await wordStore.getWords()
+    console.time("[PyramidService] getAllPyramids")
+    const [getWordsErr, allWords] = await wordStore.getWords()
     if (getWordsErr) {
       return [getWordsErr, null] as const
     }
+
+    const words = allWords.filter((l) => l.length <= 5)
 
     // anagramLookup helper resolves word => all anagrams super quickly.
     const anagramLookup = makeAnagramLookup()
@@ -48,6 +50,7 @@ export const makePyramidService = (
         }
       }
     }
+    console.log("Graph size is", graph.size())
 
     const pyramidDepth = 5
     const topLevelWords = words.filter((w) => w.length == pyramidDepth)
@@ -56,7 +59,7 @@ export const makePyramidService = (
       findAllPyramids(graph, anagramLookup, allPyramidSolutions, w, 5, [])
     }
 
-    console.timeEnd("[PyramidService] getAllPyramids");
+    console.timeEnd("[PyramidService] getAllPyramids")
     return [null, { allPyramidSolutions, graph }] as const
   }
 

--- a/packages/backend/src/service/pyramidService.ts
+++ b/packages/backend/src/service/pyramidService.ts
@@ -13,8 +13,8 @@ export const makePyramidService = (
   wordStore: WordStoreService,
   store: PyramidStoreAdapter,
 ) => {
-  const getAllPyramids = async () => {
-    console.time("[PyramidService] getAllPyramids")
+  const getGraphAndStartingWords = async () => {
+    console.time("[getGraphAndStartingWords] getAllPyramids")
     const [getWordsErr, allWords] = await wordStore.getWords()
     if (getWordsErr) {
       return [getWordsErr, null] as const
@@ -33,6 +33,7 @@ export const makePyramidService = (
     // Aka, X minus one character is an anagram of Y
     // Example:
     // fare => [far, are]
+    console.time("[getGraphAndStartingWords] build graph")
     const graph = makeWordRelationGraph()
     for (const word of words) {
       for (let i = 0; i < word.length; i++) {
@@ -50,33 +51,52 @@ export const makePyramidService = (
         }
       }
     }
+    console.timeEnd("[getGraphAndStartingWords] build graph")
     console.log("Graph size is", graph.size())
 
     const pyramidDepth = 5
     const topLevelWords = words.filter((w) => w.length == pyramidDepth)
-    const allPyramidSolutions = new Array<Array<string>>()
-    for (const w of topLevelWords) {
-      findAllPyramids(graph, anagramLookup, allPyramidSolutions, w, 5, [])
-    }
+    const startingWords = new Array<string>()
 
-    console.timeEnd("[PyramidService] getAllPyramids")
-    return [null, { allPyramidSolutions, graph }] as const
+    console.time("[getGraphAndStartingWords] find starting words")
+    for (const w of topLevelWords) {
+      if (isRootOfPyramid(graph, anagramLookup, w, 5)) {
+        startingWords.push(w)
+      }
+    }
+    console.timeEnd("[getGraphAndStartingWords] find starting words")
+
+    console.timeEnd("[getGraphAndStartingWords] getAllPyramids")
+    return [null, { startingWords, graph, anagramLookup }] as const
   }
 
   const generate = async (strSeed: string) => {
     console.log("[pyramidService] generate game from seed", strSeed)
-    const [err, result] = await getAllPyramids()
+    const [err, result] = await getGraphAndStartingWords()
     if (err) {
       console.error("[pyramidService] Error generating game", err)
       return [err, null] as const
     }
-    const { allPyramidSolutions, graph } = result
+    const { startingWords, graph, anagramLookup } = result
 
     const rand = seedrandom(strSeed)
-    const randomIndex = Math.floor(rand() * allPyramidSolutions.length)
-    const pyramid = allPyramidSolutions[randomIndex]
+    const startingWord =
+      startingWords[Math.floor(rand() * startingWords.length)]
+    console.log("[pyramidService] starting word is:", startingWord)
 
-    const startingWord = pyramid[0]
+    console.time("[pyramidService] find all pyramids from starting word")
+    const solutions = new Array<Array<string>>()
+    findAllPyramids(
+      graph,
+      anagramLookup,
+      solutions,
+      startingWord,
+      5,
+      new Array(),
+    )
+    const pyramid = solutions[Math.floor(rand() * solutions.length)]
+    console.timeEnd("[pyramidService] find all pyramids from starting word")
+
     // copy subgraph of solutions for verification later
     const subgraphOfSolutions = makeWordRelationGraph()
 
@@ -301,7 +321,7 @@ const findAllPyramids = (
   // if there are no relations in the graph, then there doesn't exist any anagram for this word minus any character
   if (!relations) return
 
-  for (const relatedChars of [...relations]) {
+  for (const relatedChars of relations) {
     const relatedWords = anagramLookup.getAnagrams(relatedChars)
     if (!relatedWords) return
     for (const relatedWord of relatedWords) {
@@ -310,6 +330,32 @@ const findAllPyramids = (
       ])
     }
   }
+}
+
+const isRootOfPyramid = (
+  graph: WordRelationGraph,
+  anagramLookup: AnagramLookup,
+  word: string,
+  // current depth, descending
+  depth: number,
+) => {
+  if (depth === 1) {
+    return true
+  }
+  const relations = graph.getRelation(word)
+  if (!relations) return false
+
+  for (const relatedChars of relations) {
+    const relatedWords = anagramLookup.getAnagrams(relatedChars)
+    if (!relatedWords) return
+    for (const relatedWord of relatedWords) {
+      if (isRootOfPyramid(graph, anagramLookup, relatedWord, depth - 1)) {
+        return true
+      }
+    }
+  }
+
+  return false
 }
 
 const flattenGraph = (

--- a/packages/common/src/word-utils/anagramLookup.ts
+++ b/packages/common/src/word-utils/anagramLookup.ts
@@ -14,6 +14,7 @@ export const makeAnagramLookup = () => {
   const getAll = () => anagramMap
 
   return {
+    toHash,
     insert,
     getAnagrams,
     getAll,

--- a/packages/common/src/word-utils/wordRelationGraph.ts
+++ b/packages/common/src/word-utils/wordRelationGraph.ts
@@ -71,6 +71,10 @@ export const makeWordRelationGraph = (
     }
   }
 
+  const size = () => {
+    return relations.size
+  }
+
   return {
     addDirectedRelation,
     filterRelations,
@@ -78,6 +82,7 @@ export const makeWordRelationGraph = (
     serialize,
     copy,
     traverse,
+    size,
   }
 }
 
@@ -102,4 +107,5 @@ export type WordRelationGraph = {
   copy: (graph: WordRelationGraph, word: string) => void
   filterRelations: (filterFn: FilterFn) => void
   traverse: (word: string, visitFn: VisitFn, visited: Set<string>) => void
+  size: () => number
 }


### PR DESCRIPTION
recently we did a fix to anagramhelper - which now returns the proper (a lot more) results per word.  As a result our strategy of generating all pyramids causes an OOM.  there's definitely a better way to do this but for now let's just increase memory, currently our max heap is 2mb, so i've increased it to 4mb locally & for deployments.